### PR TITLE
Track citations of my core papers (cites-me)

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Install paper-feeder, score, and write the digest into feed/.
       # State lives in .paper-feeder/ (a dot-dir Jekyll excludes from the build).
-      - uses: alex-robinson/paper-feeder@v0.1.5
+      - uses: alex-robinson/paper-feeder@v0.1.8
         with:
           config: config
           data: .paper-feeder

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -44,6 +44,15 @@ openalex:
   queries:
     - {name: cryosphere, filter: "primary_topic.id:T10644"}     # Cryospheric studies and observations
     - {name: paleoclimate, filter: "primary_topic.id:T10017"}   # Geology and Paleoclimatology Research
+  # Citations of my core cryosphere/paleoclimate papers (Scholar-style alerts).
+  # score_boost gives partial credit — a citing paper still needs some topical
+  # signal to clear publish_min_score, so citations from unrelated fields (my
+  # broad climate-impacts papers attract plenty) stay out. Deliberately NOT my
+  # most-cited papers; these are the topically core ones.
+    - name: cites-me
+      score_boost: 2
+      lookback_days: 180   # citations trickle in and are indexed late
+      filter: "cites:W2897498392|W1970866483|W2770103723|W4402229072|W4387730333|W4214540129|W2553339343|W1982345626|W2143602567|W2010594743|W2164162301|W2516967240|W297089026|W4288084487|W2729847169|W2027390906"
   # ISSN pulls for journals without a working RSS feed.
   issns:
     - "0022-1430"   # Journal of Glaciology


### PR DESCRIPTION
Adds a Scholar-style citation alert via OpenAlex — no scraping, no API key.

- `cites-me` query over my 16 topically-core cryosphere/paleoclimate papers.
- `score_boost: 2` — partial credit rather than a hard bypass, so a citing paper still needs some topical signal. Verified: the only citation in the current window was a CO2-membrane chemistry paper, which correctly scored 2 and dropped out.
- `lookback_days: 180` — citations trickle in (1 per 14d, 18 per 60d, 116 per year) and are indexed late, so a narrow window would miss them permanently.
- Bumps to paper-feeder v0.1.8.

Config only — no regenerated feed here, since `config/scoring.yaml` is mid-revision locally. The next scheduled run rebuilds it.